### PR TITLE
Change lockfile path to user folder

### DIFF
--- a/src/main/kotlin/com/skide/core/management/SocketManager.kt
+++ b/src/main/kotlin/com/skide/core/management/SocketManager.kt
@@ -17,7 +17,7 @@ class SocketManager(val core: CoreManager) {
     private var running = false
     fun start() {
 
-        val lockfile = File(File(CoreManager::class.java.protectionDomain.codeSource.location.toURI()).parent, "lockfile")
+        val lockfile = File(System.getProperty("user.home"), ".skide_lockfile")
         var start = 45664
 
         while (true) {


### PR DESCRIPTION
To make packaging of SkIDE easier, the lockfile should be created in a user-writable location like "user.home", as SkIDE may be installed in a non writable location.