### PR TITLE
Change Gradle project name from Sk-IDE to SkIDE

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,4 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
-rootProject.name = 'Sk-IDE'
+rootProject.name = 'SkIDE'


### PR DESCRIPTION
For some reason the gradle project name was Sk-IDE and was never updated. This PR removes the dash from the name, to make it more consistent with everything else.